### PR TITLE
Remove nils from list returned by bundle-list-gems

### DIFF
--- a/bundler.el
+++ b/bundler.el
@@ -149,7 +149,7 @@
             (match-string 1 line)
           nil))
 
-      (mapcar 'parse-bundle-list-line bundle-lines))))
+      (remq nil (mapcar 'parse-bundle-list-line bundle-lines)))))
 
 (provide 'bundler)
 ;;; bundler.el ends here.


### PR DESCRIPTION
On Emacs 24.1 I had a nil element in the front of the candidates list when calling bundle-open and using ido. This seems to fix that.
