### PR TITLE
bundle-locate-gemfile is not defined when installed from MELPA

### DIFF
--- a/bundler.el
+++ b/bundler.el
@@ -7,7 +7,7 @@
 ;; Keywords: bundler ruby
 ;; Created: 31 Dec 2011
 ;; Version: 1.1.0
-;; Package-Requires: ((inf-ruby "2.1"))
+;; Package-Requires: ((cl-lib "0.2") (inf-ruby "2.1"))
 
 ;; This file is NOT part of GNU Emacs.
 
@@ -60,6 +60,7 @@
 
 ;;; Code:
 
+(require 'cl-lib)
 (require 'inf-ruby)
 
 ;;;###autoload


### PR DESCRIPTION
The defun* macro is provided by cl-lib and is not specified as a dependency in bundler.el's elisp header.  So commands that search for a Gemfile with bundle-locate-gemfile fail.  I'm not sure how to test this, but the change is simple enough.