### PR TITLE
Add (require 'cl) for Emacs 24.4.1

### DIFF
--- a/bundler.el
+++ b/bundler.el
@@ -59,7 +59,7 @@
 ;; Boston, MA 02110-1301, USA.
 
 ;;; Code:
-
+(require 'cl)
 (require 'inf-ruby)
 
 ;;;###autoload


### PR DESCRIPTION
In order to use the `defun*` function in Emacs 24.4.1, you must
explicitly `(require 'cl)`.

Fixes #9.
