### PR TITLE
Suppress compile warning message.

### DIFF
--- a/bundler.el
+++ b/bundler.el
@@ -7,7 +7,7 @@
 ;; Keywords: bundler ruby
 ;; Created: 31 Dec 2011
 ;; Version: 1.1.1
-;; Package-Requires: ((inf-ruby "2.1"))
+;; Package-Requires: ((inf-ruby "2.1") (cl-lib "0.5")
 
 ;; This file is NOT part of GNU Emacs.
 
@@ -59,7 +59,8 @@
 ;; Boston, MA 02110-1301, USA.
 
 ;;; Code:
-(require 'cl)
+
+(require 'cl-lib)
 (require 'inf-ruby)
 
 ;;;###autoload
@@ -150,17 +151,17 @@ found."
   (make-hash-table)
   "Holds a hash table of gem lists per directory.")
 
-(defun* bundle-locate-gemfile (&optional (dir default-directory))
-  (let ((has-gemfile (directory-files dir nil "^Gemfile$"))
-        (is-root (equal dir "/")))
-    (cond
-     (has-gemfile dir)
-     (is-root
-      (print (format
-              "No Gemfile found in either %s or any parent directory!"
-              default-directory))
-      nil)
-     ((bundle-locate-gemfile (expand-file-name ".." dir))))))
+(cl-defun bundle-locate-gemfile (&optional (dir default-directory))
+         (let ((has-gemfile (directory-files dir nil "^Gemfile$"))
+               (is-root (equal dir "/")))
+           (cond
+            (has-gemfile dir)
+            (is-root
+             (print (format
+                     "No Gemfile found in either %s or any parent directory!"
+                     default-directory))
+             nil)
+            ((bundle-locate-gemfile (expand-file-name ".." dir))))))
 
 (defun bundle-list-gems-cached ()
   (let* ((gemfile-dir (bundle-locate-gemfile))


### PR DESCRIPTION
This commit suppresses the following compile time warning message.
![screen shot 2015-01-23 at 2 33 07 pm](https://cloud.githubusercontent.com/assets/3055936/5870754/3e49e17c-a30e-11e4-9e53-f3dd668f46d6.png)

```
In toplevel form:
bundler.el:63:1:Warning: cl package required at runtime
```

cl is deprecated in favor of cl-lib.
And all common lisp call should have ``cl-`` prefix.