### PR TITLE
Fix unsetenv

### DIFF
--- a/bundler.el
+++ b/bundler.el
@@ -132,7 +132,7 @@
             (setenv "BUNDLE_GEMFILE" gemfile)
             (message "BUNDLE_GEMFILE set to: %s." gemfile))
         (message "Warning: couldn't read file \"%s\". BUNDLE_GEMFILE unchanged." gemfile))
-    (unsetenv "BUNDLE_GEMFILE")))
+    (setenv "BUNDLE_GEMFILE")))
 
 (defun bundle-command (cmd)
   "Run cmd in an async buffer."


### PR DESCRIPTION
```
Compiling file /Users/arthurnn/.emacs.d/elpa/bundler-20150527.229/bundler-autoloads.el at Wed May 27 15:03:40 2015
Entering directory `/Users/arthurnn/.emacs.d/elpa/bundler-20150527.229/'

Compiling file /Users/arthurnn/.emacs.d/elpa/bundler-20150527.229/bundler-pkg.el at Wed May 27 15:03:40 2015

Compiling file /Users/arthurnn/.emacs.d/elpa/bundler-20150527.229/bundler.el at Wed May 27 15:03:40 2015

In end of data:
bundler.el:220:1:Warning: the function `unsetenv' is not known to be defined.
```