### PR TITLE
Update bundler.el

### DIFF
--- a/bundler.el
+++ b/bundler.el
@@ -128,7 +128,6 @@
   (if gemfile
       (if (file-readable-p gemfile)
           (progn
-            (setq bundle-gem-list-cache (make-hash-table))
             (setenv "BUNDLE_GEMFILE" gemfile)
             (message "BUNDLE_GEMFILE set to: %s." gemfile))
         (message "Warning: couldn't read file \"%s\". BUNDLE_GEMFILE unchanged." gemfile))


### PR DESCRIPTION
Getting a `Warning: assignment to free variable: bundle-gem-list-cache`

I think we dont need to define that ivar again, as it is already defined on line 168