### PR TITLE
Get a list of paths to bundled gems

### DIFF
--- a/bundler.el
+++ b/bundler.el
@@ -214,5 +214,11 @@ found."
 
       (remq nil (mapcar 'parse-bundle-list-line bundle-lines)))))
 
+(defun bundle-list-gem-paths ()
+  (save-excursion
+    (let* ((cmd "bundle list --paths")
+           (bundle-out (shell-command-to-string cmd)))
+      (split-string bundle-out "\n"))))
+
 (provide 'bundler)
 ;;; bundler.el ends here.


### PR DESCRIPTION
Add `bundle-list-gem-paths` that returns a list of paths to bundled
gems.