### PR TITLE
Fix Package-Requires syntax error

### DIFF
--- a/bundler.el
+++ b/bundler.el
@@ -7,7 +7,7 @@
 ;; Keywords: bundler ruby
 ;; Created: 31 Dec 2011
 ;; Version: 1.1.1
-;; Package-Requires: ((inf-ruby "2.1") (cl-lib "0.5")
+;; Package-Requires: ((inf-ruby "2.1") (cl-lib "0.5"))
 
 ;; This file is NOT part of GNU Emacs.
 


### PR DESCRIPTION
emacs melpa can't correctly install package dependencies due to Package-Requires syntax error