### PR TITLE
Fix locating gem when bundle show process outputs warnings

### DIFF
--- a/bundler.el
+++ b/bundler.el
@@ -187,19 +187,16 @@ found."
                 "bundle info --path"))
          (bundler-stdout
           (shell-command-to-string
-           (format "%s %s" cmd (shell-quote-argument gem-name))))
-         (remote (file-remote-p default-directory)))
+           (format "%s %s" cmd (shell-quote-argument gem-name)))))
     (cond
      ((string-match "Could not locate Gemfile" bundler-stdout)
       'no-gemfile)
      ((string-match "Could not find " bundler-stdout)
       nil)
      (t
-      (concat remote
-              (replace-regexp-in-string
-               "Resolving dependencies...\\|The dependency .* will be unused by .*$\\|\n" ""
-               bundler-stdout)
-              "/")))))
+      (seq-find
+       (lambda (line) (string-match-p "^\\/" line))
+       (reverse (split-string bundler-stdout "[\n]")))))))
 
 (defvar bundle-gem-list-cache
   (make-hash-table)


### PR DESCRIPTION
On my project `bundle show --path` gives such output:
```
Your Gemfile lists the gem rack-mini-profiler (>= 0) more than once.
You should probably keep only one of them.
Remove any duplicate entries and specify the gem only once (per group).
While it's not a problem now, it could cause errors if you change the version of one of them later.
/Users/asok/.gem/ruby/2.6.3/gems/actioncable-6.0.2.1
```

This output breaks the command `bundle-open`.

The change assumes that the last line contains the actual path to the gem, the rest is ignored.
My change also removes the local variable `remote`. I'm not quite sure what is the purpose of it? When it was `t` and passing it as a first argument to `concat` is causing an error.